### PR TITLE
feat: Integrate LXP balance, POH status and activations

### DIFF
--- a/packages/snap/locales/en.json
+++ b/packages/snap/locales/en.json
@@ -1,11 +1,13 @@
 {
   "locale": "en",
-  "noAttestations": "You do not have any attestations.",
-  "detail": {
-    "caption": "Your {count} Attestations",
-    "from": "From",
-    "attestedOn": "Attested On",
-    "expiry": "Expiry",
-    "content": "Content"
+  "poh": {
+    "status": "Your POH status:",
+    "verified": "Verified",
+    "notVerified": "Not verified"
+  },
+  "lxp": "You have {count} LXP",
+  "activations": {
+    "number": "There are {count} active LXP activations",
+    "none": "There are no current activation"
   }
 }

--- a/packages/snap/locales/es.json
+++ b/packages/snap/locales/es.json
@@ -1,11 +1,13 @@
 {
   "locale": "es",
-  "noAttestations": "No tienes certificaciones.",
-  "detail": {
-    "caption": "Tienes {count} Certificaciones",
-    "from": "De",
-    "attestedOn": "Certificado En",
-    "expiry": "Expiracion",
-    "content": "Contenido"
+  "poh": {
+    "status": "Tu estado de POH:",
+    "verified": "Verificado",
+    "notVerified": "No verificado"
+  },
+  "lxp": "Tienes {count} LXP",
+  "activations": {
+    "number": "Hay {count} activationes de LXP activas",
+    "none": "No hay activas activaciones de LXP"
   }
 }

--- a/packages/snap/locales/fr.json
+++ b/packages/snap/locales/fr.json
@@ -1,11 +1,13 @@
 {
   "locale": "fr",
-  "noAttestations": "Vous n'avez aucune attestation.",
-  "detail": {
-    "caption": "Vos {count} Attestations",
-    "from": "Émise par",
-    "attestedOn": "Attestée le",
-    "expiry": "Expiration",
-    "content": "Contenu"
+  "poh": {
+    "status": "Votre statut POH:",
+    "verified": "Vérifié",
+    "notVerified": "Non vérifié"
+  },
+  "lxp": "Vous avez {count} LXP",
+  "activations": {
+    "number": "Il y a {count} activations LXP actives",
+    "none": "Il n'y a pas d'activation active"
   }
 }

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Consensys/lxp-snap"
   },
   "source": {
-    "shasum": "fDfYxMbAs5TKesXACqMldOYo2Qpr/nWIJIvEd3jVK+8=",
+    "shasum": "ajhbYlb5UCt6d4OF/ddPDxJorbycV9VRv3kO+aairsw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/api.ts
+++ b/packages/snap/src/api.ts
@@ -1,96 +1,23 @@
-import type { Portal, RawAttestation, Schema } from './types';
-
-const postData = async (url: string, data: { query: string }) => {
+const getData = async (url: string) => {
   const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(data),
+    method: 'GET',
   });
   return response.json();
 };
 
-const getSubgraphUrl = (chainId: string) => {
-  switch (chainId) {
-    case '0xe704': // Linea Testnet
-      return 'https://api.goldsky.com/api/public/project_clqghnrbp9nx201wtgylv8748/subgraphs/verax/subgraph-testnet/gn';
-    case '0x66eed': // Arbitrum Goerli
-      return 'https://api.thegraph.com/subgraphs/name/cliqueofficial/verax-arbitrum-goerli';
-    case '0xa4b1': // Arbitrum Mainnet
-      return 'https://api.thegraph.com/subgraphs/name/cliqueofficial/verax-arbitrum';
-    default: // Linea Mainnet
-      return 'https://graph-query.linea.build/subgraphs/name/Consensys/linea-attestation-registry';
-  }
+export const fetchBalanceFromLineascan = async (address: string) => {
+  const res = await getData(
+    `https://api.lineascan.build/api?module=account&action=tokenbalance&contractaddress=0xd83af4fbD77f3AB65C3B1Dc4B38D7e67AEcf599A&address=${address}&tag=latest`,
+  );
+  return res.result as string;
 };
 
-export const getPortal = async (
-  chainId: string,
-  portalId: string,
-): Promise<Portal> => {
-  const data = {
-    query: `query { portal(id: "${portalId}") {
-                  description
-                  id
-                  isRevocable
-                  modules
-                  name
-                  ownerAddress
-                  ownerName
-                }
-            }`,
-  };
-
-  const rawResponse = await postData(getSubgraphUrl(chainId), data);
-
-  return rawResponse ? rawResponse.data.portal : {};
+export const fetchPohStatus = async (address: string) => {
+  return await getData(`https://linea-xp-poh-api.linea.build/poh/${address}`);
 };
 
-export const getSchema = async (
-  chainId: string,
-  portalId: string,
-): Promise<Schema> => {
-  const data = {
-    query: `query { schema(id: "${portalId}") {
-                  id
-                  name
-                  description
-                  context
-                  schema
-                }
-            }`,
-  };
-
-  const rawResponse = await postData(getSubgraphUrl(chainId), data);
-
-  return rawResponse ? rawResponse.data.schema : {};
-};
-
-export const fetchAttestations = async (
-  chainId: string,
-  address: string,
-): Promise<RawAttestation[]> => {
-  const data = {
-    query: `query { attestations(where: { subject: "${address}" }) {
-              id
-              schemaId
-              replacedBy
-              attester
-              portal
-              attestedDate
-              expirationDate
-              revocationDate
-              version
-              revoked
-              subject
-              attestationData
-              schemaString
-              decodedData
-            }
-          }`,
-  };
-
-  const rawResponse = await postData(getSubgraphUrl(chainId), data);
-
-  return rawResponse ? rawResponse.data.attestations : [];
+export const fetchAllActivations = async () => {
+  return getData(
+    `https://linea.build/_next/data/lBB9x4X_1g5kiNOCmMwHZ/activations.json?slug=activations`,
+  );
 };

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -1,7 +1,11 @@
 import type { OnHomePageHandler } from '@metamask/snaps-sdk';
 
-import { getAttestationsForAddress } from './service';
-import { showAttestationList } from './ui';
+import {
+  getCurrentActivations,
+  getLxpBalanceForAddress,
+  getPohStatus,
+} from './service';
+import { renderMainUi } from './ui';
 import { getAccount, getChainId, setState } from './utils';
 
 export const onHomePage: OnHomePageHandler = async () => {
@@ -16,14 +20,19 @@ export const onHomePage: OnHomePageHandler = async () => {
     captions = await import(`../locales/en.json`);
   }
 
-  const myAccount = await getAccount();
   const chainId = await getChainId();
-  const myAttestations = await getAttestationsForAddress(chainId, myAccount);
+
+  const myAccount = await getAccount();
+  const myLxpBalance = await getLxpBalanceForAddress(myAccount, chainId);
+  const myPohStatus = await getPohStatus(myAccount);
+  const activations = await getCurrentActivations();
 
   await setState({
     captions,
-    myAttestations,
+    myLxpBalance,
+    myPohStatus,
+    activations,
   });
 
-  return showAttestationList();
+  return renderMainUi(myAccount);
 };

--- a/packages/snap/src/service.ts
+++ b/packages/snap/src/service.ts
@@ -1,30 +1,78 @@
-import { fetchAttestations, getPortal, getSchema } from './api';
-import type { Attestation } from './types';
+import {
+  fetchAllActivations,
+  fetchBalanceFromLineascan,
+  fetchPohStatus,
+} from './api';
+import type { Activation } from './types';
+import { convertBalanceToDisplay } from './utils';
 
 /**
- * Get attestations for an address.
- * @param chainId - The chain ID.
- * @param address - The address to get attestations for.
- * @returns The attestations for the address.
+ * Get the LXP balance for an address from Lineascan.
+ * @param address - The address to get the LXP balance for.
+ * @returns The LXP balance for the address.
  */
-export async function getAttestationsForAddress(
-  chainId: string,
+async function getLxpBalanceFromLineascan(address: string) {
+  const rawBalance = await fetchBalanceFromLineascan(address);
+  return convertBalanceToDisplay(rawBalance);
+}
+
+/**
+ * Get the LXP balance for an address from the chain.
+ * @param address - The address to get the LXP balance for.
+ * @returns The LXP balance for the address.
+ */
+async function getLxpBalanceFromChain(address: string) {
+  const method = 'eth_call';
+  const params = [
+    {
+      to: '0xd83af4fbD77f3AB65C3B1Dc4B38D7e67AEcf599A',
+      data: `0x70a08231000000000000000000000000${address.slice(2)}`,
+    },
+    'latest',
+  ];
+
+  const rawBalance = await ethereum.request<string>({ method, params });
+
+  return convertBalanceToDisplay(rawBalance);
+}
+
+/**
+ * Get the LXP balance for an address.
+ * @param address - The address to get the LXP balance for.
+ * @param chainId - The chain ID.
+ * @returns The LXP balance for the address.
+ */
+export async function getLxpBalanceForAddress(
   address: string,
+  chainId: string,
 ) {
-  const rawAttestations = await fetchAttestations(chainId, address);
+  if (chainId === '0xe708') {
+    return getLxpBalanceFromChain(address);
+  }
+  return getLxpBalanceFromLineascan(address);
+}
 
-  return await Promise.all(
-    rawAttestations.map(async (a) => {
-      const portal = await getPortal(chainId, a.portal);
-      const schema = await getSchema(chainId, a.schemaId);
+/**
+ * Get the POH status for an address.
+ * @param address - The address to get the POH status for.
+ * @returns The POH status for the address.
+ */
+export async function getPohStatus(address: string) {
+  const pohStatus = await fetchPohStatus(address);
+  return pohStatus.poh as boolean;
+}
 
-      return {
-        id: a.id,
-        from: portal.ownerName,
-        attestationDate: parseInt(a.attestedDate, 10) * 1000,
-        expiryDate: parseInt(a.expirationDate, 10) * 1000,
-        content: schema.name,
-      } as Attestation;
-    }),
-  );
+/**
+ * Get the current activations.
+ * @returns The current activations.
+ */
+export async function getCurrentActivations() {
+  const rawResponse = await fetchAllActivations();
+  const allActivations =
+    rawResponse?.pageProps?.pageLayout?.sections?.[0]?.items?.[0]?.items ?? [];
+  return allActivations.filter((activation: Activation) => {
+    const isCurrent = new Date(activation?.endDate) > new Date();
+    const hasXpTag = activation?.tags?.find((tag) => tag.name === 'Get XP');
+    return isCurrent && hasXpTag;
+  });
 }

--- a/packages/snap/src/types/index.ts
+++ b/packages/snap/src/types/index.ts
@@ -1,59 +1,32 @@
-export type RawAttestation = {
-  id: string;
-  schemaId: string;
-  replacedBy: string;
-  attester: string;
-  portal: string;
-  attestedDate: string;
-  expirationDate: string;
-  revocationDate: string;
-  version: string;
-  revoked: string;
-  subject: string;
-  attestationData: string;
-  schemaString: string;
-  decodedData: string;
-};
-
-export type Attestation = {
-  id: string;
-  content: string;
-  from: string;
-  attestationDate: number;
-  expiryDate: number;
-};
-
-export type Portal = {
-  id: string;
-  description: string;
-  isRevocable: string;
-  modules: string;
-  name: string;
-  ownerAddress: string;
-  ownerName: string;
-};
-
-export type Schema = {
-  id: string;
-  name: string;
-  description: string;
-  context: string;
-  schema: string;
-};
-
 export type Captions = {
   locale: string;
   noAttestations: string;
-  detail: {
-    caption: string;
-    from: string;
-    attestedOn: string;
-    expiry: string;
-    content: string;
+  poh: {
+    status: string;
+    verified: string;
+    notVerified: string;
+  };
+  lxp: string;
+  activations: {
+    number: string;
+    none: string;
   };
 };
 
+export type Tag = {
+  name: string;
+};
+
+export type Activation = {
+  title: string;
+  url: string;
+  endDate: string;
+  tags: Tag[];
+};
+
 export type SnapState = {
-  captions?: Captions;
-  myAttestations?: Attestation[];
+  captions: Captions;
+  myLxpBalance?: number;
+  myPohStatus?: boolean;
+  activations?: Activation[];
 };

--- a/packages/snap/src/ui.ts
+++ b/packages/snap/src/ui.ts
@@ -1,41 +1,43 @@
-import { divider, heading, panel, row, text } from '@metamask/snaps-sdk';
+import { heading, panel, text } from '@metamask/snaps-sdk';
 
 import { getState } from './utils';
 
 /**
- * Show the attestation list page.
- * @returns The attestation list page.
+ * Render the main UI.
+ * @param myAccount - The account to render the UI for.
+ * @returns The main UI.
  */
-export async function showAttestationList() {
+export async function renderMainUi(myAccount: string) {
   const snapState = await getState();
   const attestations = snapState?.myAttestations ?? [];
+  const lxpBalance = snapState?.myLxpBalance ?? 0;
+  const activations = snapState?.activations ?? [];
   const captions = snapState?.captions;
 
-  const attestationItems = await Promise.all(
-    attestations.map(async (attestation) => [
-      divider(),
-      row(captions?.detail.from, text(attestation.from)),
-      row(
-        captions?.detail.attestedOn,
-        text(new Date(attestation.attestationDate).toDateString()),
-      ),
-      row(
-        captions?.detail.expiry,
-        text(new Date(attestation.expiryDate).toDateString()),
-      ),
-      row(captions?.detail.content, text(attestation.content)),
-    ]),
-  );
-
-  const headingCaption =
+  const lxpCount =
     attestations.length > 0
-      ? (captions?.detail.caption as string).replace(
-          '{count}',
-          `${attestationItems.length}`,
-        )
-      : (captions?.noAttestations as string);
+      ? captions.lxp.replace('{count}', `${lxpBalance}`)
+      : captions.noAttestations;
+
+  const pohStatus = `${captions?.poh.status} ${
+    snapState?.myPohStatus
+      ? `✅ ${captions.poh.verified}`
+      : `❌ ${captions.poh.notVerified}`
+  }`;
+
+  const activationsToDisplay =
+    activations?.length > 0
+      ? captions.activations.number.replace('{count}', `${activations.length}`)
+      : captions.activations.none;
 
   return {
-    content: panel([heading(headingCaption), ...attestationItems.flat()]),
+    content: panel([
+      heading(lxpCount),
+      text(`[Lineascan](https://lineascan.build/address/${myAccount})`),
+      heading(pohStatus),
+      text('[POH page](https://poh.linea.build)'),
+      heading(activationsToDisplay),
+      text('[Activations page](https://linea.build/activations)'),
+    ]),
   };
 }

--- a/packages/snap/src/utils.ts
+++ b/packages/snap/src/utils.ts
@@ -72,3 +72,16 @@ export async function getChainId() {
 
   return chainId;
 }
+
+/**
+ * Convert the raw balance to a displayable balance.
+ * @param rawBalance - The raw balance.
+ * @returns The displayable balance.
+ */
+export function convertBalanceToDisplay(rawBalance?: string | null) {
+  if (!rawBalance || rawBalance === '0x') {
+    return 0;
+  }
+
+  return Number(BigInt(rawBalance) / BigInt(10 ** 18));
+}


### PR DESCRIPTION
Integrates 3 calls:
1. Get LXP balance (from the contract if connected on Linea, from Lineascan if connected on an other network)
2. Get POH status (from the POH API)
3. Get the currently active activations giving LXP (from the Contentful API)