### PR TITLE
feat: Display LXP-L balance and Linea ENS domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Linea Voyager Snap
 
-View your LXP and LXP-L balances, Proof of Humanity status, and current LXP Activations right inside of MetaMask!
+View your minted LXP and LXP-L balances, POH status, Linea ENS domain and current LXP activations. right inside of
+MetaMask!
 
 Powered by https://lineascan.build APIs and [MetaMask Snaps](https://metamask.io/snaps).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Linea Voyager Snap
 
-View your Linea XP balance, Proof of Humanity status, and current LXP Activations right inside of MetaMask!
+View your Linea XP and XP-L balances, Proof of Humanity status, and current LXP Activations right inside of MetaMask!
 
 Powered by https://lineascan.build APIs and [MetaMask Snaps](https://metamask.io/snaps).
 
@@ -12,7 +12,8 @@ Clone this repository to your local machine and set up the development environme
 yarn install && yarn start
 ```
 
-Open your browser and navigate to `http://localhost:3000` to access the production dapp or `http://localhost:8000` to access the development dapp.
+Open your browser and navigate to `http://localhost:3000` to access the production dapp or `http://localhost:8000` to
+access the development dapp.
 
 ## Cloning
 
@@ -43,5 +44,6 @@ Scripts are disabled by default for security reasons. If you need to use NPM
 packages with scripts, you can run `yarn allow-scripts auto`, and enable the
 script in the `lavamoat.allowScripts` section of `package.json`.
 
-See the documentation for [@lavamoat/allow-scripts](https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts)
+See the documentation
+for [@lavamoat/allow-scripts](https://github.com/LavaMoat/LavaMoat/tree/main/packages/allow-scripts)
 for more information.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Linea Voyager Snap
 
-View your Linea XP and XP-L balances, Proof of Humanity status, and current LXP Activations right inside of MetaMask!
+View your LXP and LXP-L balances, Proof of Humanity status, and current LXP Activations right inside of MetaMask!
 
 Powered by https://lineascan.build APIs and [MetaMask Snaps](https://metamask.io/snaps).
 

--- a/packages/dev-site/src/components/Header.tsx
+++ b/packages/dev-site/src/components/Header.tsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import styled, { useTheme } from 'styled-components';
 
 import { MetamaskActions, MetaMaskContext } from '../hooks';
-import { connectSnap, getThemePreference, getSnap } from '../utils';
+import { connectSnap, getSnap, getThemePreference } from '../utils';
 import { HeaderButtons } from './Buttons';
 import { SnapLogo } from './SnapLogo';
 import { Toggle } from './Toggle';
@@ -21,6 +21,7 @@ const Title = styled.p`
   font-weight: bold;
   margin: 0;
   margin-left: 1.2rem;
+
   ${({ theme }) => theme.mediaQueries.small} {
     display: none;
   }
@@ -67,7 +68,7 @@ export const Header = ({
     <HeaderWrapper>
       <LogoWrapper>
         <SnapLogo color={theme.colors.icon?.default} size={36} />
-        <Title>LXP Snap</Title>
+        <Title>Linea Voyager Snap</Title>
       </LogoWrapper>
       <RightContainer>
         <Toggle

--- a/packages/dev-site/src/pages/index.tsx
+++ b/packages/dev-site/src/pages/index.tsx
@@ -141,7 +141,7 @@ const Index = () => {
   return (
     <Container>
       <Heading>
-        <Span>LXP Snap</Span>
+        <Span>Linea Voyager Snap</Span>
       </Heading>
       <CardContainer>
         {state.error && (

--- a/packages/functions/global-api.ts
+++ b/packages/functions/global-api.ts
@@ -1,0 +1,196 @@
+import type { Activation } from '@consensys/linea-voyager/src/types';
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json',
+};
+
+export const LXP_CONTRACT_ADDRESS =
+  '0xd83af4fbD77f3AB65C3B1Dc4B38D7e67AEcf599A';
+export const LXP_L_CONTRACT_ADDRESS =
+  '0x96B3a15257c4983A6fE9073D8C91763433124B82';
+
+const LINEASCAN_API_KEY = process.env.LINEASCAN_API_KEY;
+
+/**
+ * This function is called on every network call.
+ * @param event - The event object.
+ * @param event.httpMethod - The HTTP method used by the caller.
+ * @param event.body - The HTTP request body.
+ * @returns The response object.
+ */
+export async function handler(event: {
+  queryStringParameters: { address: string; isLineascan: boolean };
+  body: string;
+  httpMethod: string;
+}) {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers,
+      body: '',
+    };
+  }
+
+  if (event.httpMethod === 'GET') {
+    if (!LINEASCAN_API_KEY) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({
+          message: 'Lineascan API key not set',
+        }),
+      };
+    }
+
+    const { address, isLineascan } = event.queryStringParameters;
+
+    if (!address || address == '') {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          message: 'Missing address parameter',
+        }),
+      };
+    }
+
+    const [activations, pohStatus, openBlockScore, lxpBalance, lxpLBalance] =
+      await Promise.all([
+        getActivations(),
+        fetchPohStatus(address),
+        getOpenBlockScore(address.toLowerCase()),
+        isLineascan
+          ? fetchBalanceFromLineascan(LXP_CONTRACT_ADDRESS, address)
+          : Promise.resolve('0'),
+        isLineascan
+          ? fetchBalanceFromLineascan(LXP_L_CONTRACT_ADDRESS, address)
+          : Promise.resolve('0'),
+      ]);
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        activations,
+        pohStatus,
+        openBlockScore,
+        lxpBalance,
+        lxpLBalance,
+      }),
+    };
+  }
+
+  return {
+    statusCode: 405,
+    headers,
+    body: JSON.stringify({
+      message: 'Method not allowed',
+    }),
+  };
+}
+
+async function getData(
+  url: string,
+  additionalHeaders?: Record<string, string>,
+) {
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      ...additionalHeaders,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    console.error(`Call to ${url} failed with status ${response.status}`);
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Get current active activations from Contentful.
+ * @returns The activations object.
+ */
+async function getActivations() {
+  const { CONTENTFUL_API_KEY } = process.env;
+  const GET_XP_TAG = '4WJBpV24ju4wlbr6Kvi2pt';
+
+  if (!CONTENTFUL_API_KEY) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: 'Contentful API key not set',
+      }),
+    };
+  }
+
+  try {
+    const res = await getData(
+      'https://api.contentful.com/spaces/64upluvbiuck/environments/master/entries/?content_type=activationsCard',
+      {
+        Authorization: CONTENTFUL_API_KEY,
+      },
+    );
+
+    const allActivations = res?.items ?? [];
+    return allActivations.filter((activation: Activation) => {
+      const isCurrent =
+        new Date(activation?.fields?.endDate?.['en-US']) > new Date();
+      const hasXpTag = activation?.fields?.tags?.['en-US']?.find(
+        (tag) => tag?.sys?.id === GET_XP_TAG,
+      );
+      return isCurrent && hasXpTag;
+    });
+  } catch (error) {
+    return [];
+  }
+}
+
+/**
+ * Get the current OpenBlock XP score for an address.
+ * @param address - The address to get the OpenBlock XP score for.
+ * @returns The OpenBlock XP score for the address.
+ */
+async function getOpenBlockScore(address: string) {
+  try {
+    const res = await getData(
+      `https://kx58j6x5me.execute-api.us-east-1.amazonaws.com/linea/userPointsSearchMetaMask?user=${address}`,
+      {
+        Origin: 'snap://linea-voyager',
+      },
+    );
+
+    return res[0].xp;
+  } catch (error) {
+    return 0;
+  }
+}
+
+async function fetchBalanceFromLineascan(
+  tokenBalance: string,
+  address: string,
+) {
+  try {
+    const res = await getData(
+      `https://api.lineascan.build/api?module=account&action=tokenbalance&contractaddress=${tokenBalance}&address=${address}&tag=latest&apiKey=${LINEASCAN_API_KEY}`,
+    );
+
+    return res.result as string;
+  } catch (e) {
+    return '0';
+  }
+}
+
+async function fetchPohStatus(address: string) {
+  try {
+    const pohPayload = await getData(
+      ` https://linea-xp-poh-api.linea.build/poh/${address}`,
+    );
+    return pohPayload.poh as boolean;
+  } catch (e) {
+    return false;
+  }
+}

--- a/packages/site/src/index.html
+++ b/packages/site/src/index.html
@@ -31,15 +31,15 @@
       </h1>
       <h2>Follow your Linea Voyage</h2>
       <p>
-        View your LXP and LXP-L balances, POH status, and current activations
-        inside of MetaMask!
+        View your minted LXP and LXP-L balances, POH status, Linea ENS domain
+        and current LXP activations inside of MetaMask!
       </p>
       <p id="loading">Loading...</p>
       <div id="context"></div>
       <p>
         After installing the Snap, open the Snaps menu in MetaMask and click on
-        Linea Voyager to view your LXP and LXP-L balances, Proof of Humanity
-        status, and current activations.
+        Linea Voyager to view your minted LXP and LXP-L balances, POH status,
+        Linea ENS domain and current LXP activations.
       </p>
       <p id="mobileCallout">
         <em>

--- a/packages/site/src/index.html
+++ b/packages/site/src/index.html
@@ -31,15 +31,15 @@
       </h1>
       <h2>Follow your Linea Voyage</h2>
       <p>
-        View your Linea XP balance, POH status, and current activations inside
-        of MetaMask!
+        View your Linea XP and XP-L balances, POH status, and current
+        activations inside of MetaMask!
       </p>
       <p id="loading">Loading...</p>
       <div id="context"></div>
       <p>
         After installing the Snap, open the Snaps menu in MetaMask and click on
-        Linea Voyager to view your Linea XP balance, Proof of Humanity status,
-        and current activations.
+        Linea Voyager to view your Linea XP and XP-L balance, Proof of Humanity
+        status, and current activations.
       </p>
       <p id="mobileCallout">
         <em>

--- a/packages/site/src/index.html
+++ b/packages/site/src/index.html
@@ -31,14 +31,14 @@
       </h1>
       <h2>Follow your Linea Voyage</h2>
       <p>
-        View your Linea XP and XP-L balances, POH status, and current
-        activations inside of MetaMask!
+        View your LXP and LXP-L balances, POH status, and current activations
+        inside of MetaMask!
       </p>
       <p id="loading">Loading...</p>
       <div id="context"></div>
       <p>
         After installing the Snap, open the Snaps menu in MetaMask and click on
-        Linea Voyager to view your Linea XP and XP-L balance, Proof of Humanity
+        Linea Voyager to view your LXP and LXP-L balances, Proof of Humanity
         status, and current activations.
       </p>
       <p id="mobileCallout">

--- a/packages/site/src/script.js
+++ b/packages/site/src/script.js
@@ -1,5 +1,5 @@
 const snapId = 'npm:@consensys/linea-voyager';
-const snapVersion = '^0.7.1';
+const snapVersion = '^0.8.0';
 let isAccountConnected = false;
 
 const isLatestVersion = (installedVersion) => {
@@ -41,9 +41,9 @@ const MetaMaskFound = async (providerDetail) => {
     if (isLatestVersion(snaps[snapId].version)) {
       // Snap is the latest version, go to step 2
       snapAlreadyInstalled(provider);
-      return; 
+      return;
     }
-    // the user is not on the latest version of the Snap 
+    // the user is not on the latest version of the Snap
     buttonLabel = 'Update Snap';
   }
   // the Snap was not installed, proceed
@@ -80,8 +80,8 @@ const MetaMaskFound = async (providerDetail) => {
         }
       }
     } catch (error) {
-      const errorMessage = document.createElement('p'); 
-      errorMessage.textContent = `${error.message}`; 
+      const errorMessage = document.createElement('p');
+      errorMessage.textContent = `${error.message}`;
       document.getElementById('context').textContent = '';
       document.getElementById('context').appendChild(errorMessage);
     }

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -1,3 +1,3 @@
 # Linea Voyager Snap
 
-View your Linea XP balance, Proof of Humanity status, and current LXP Activations right inside of MetaMask!
+View your Linea XP and XP-L balances, Proof of Humanity status, and current LXP Activations right inside of MetaMask!

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -1,3 +1,3 @@
 # Linea Voyager Snap
 
-View your Linea XP and XP-L balances, Proof of Humanity status, and current LXP Activations right inside of MetaMask!
+View your LXP and LXP-L balances, Proof of Humanity status, and current LXP Activations right inside of MetaMask!

--- a/packages/snap/README.md
+++ b/packages/snap/README.md
@@ -1,3 +1,4 @@
 # Linea Voyager Snap
 
-View your LXP and LXP-L balances, Proof of Humanity status, and current LXP Activations right inside of MetaMask!
+View your minted LXP and LXP-L balances, POH status, Linea ENS domain and current LXP activations right inside of
+MetaMask!

--- a/packages/snap/locales/en.json
+++ b/packages/snap/locales/en.json
@@ -16,6 +16,7 @@
     "none": "There are no current activations",
     "one": "There is {count} active LXP activation"
   },
+  "lineaEns": "Linea ENS domain",
   "lxpAddress": {
     "heading": "LXP wallet address",
     "prompt": "Please enter the wallet address linked to your LXP"
@@ -33,6 +34,8 @@
   "viewLxpLBalance": "View LXP-L balance on Lineascan",
   "completePOH": "Complete Proof of Humanity",
   "exploreAll": "Explore All Linea Activations",
+  "manageLineaEns": "Manage your Linea ENS domain",
+  "getLineaEns": "Get your Linea ENS domain",
   "errors": {
     "heading": "Error",
     "invalidLxpAddress": "{address} is not a valid address. Please try again."

--- a/packages/snap/locales/en.json
+++ b/packages/snap/locales/en.json
@@ -7,6 +7,7 @@
   },
   "lxp": "You have {count} LXP",
   "balance": "LXP Balance",
+  "balanceLxpL": "LXP-L Balance",
   "address": "Address",
   "pohStatus": "POH Status",
   "activations": {
@@ -27,7 +28,8 @@
     "toSetLink": "first set your address"
   },
   "help": "Your LXP balance shows only completed onchain drops. It does not include activations pending drops.",
-  "viewBalance": "View balance on Lineascan",
+  "viewBalance": "View LXP balance on Lineascan",
+  "viewLxpLBalance": "View LXP-L balance on Lineascan",
   "completePOH": "Complete Proof of Humanity",
   "exploreAll": "Explore All Linea Activations",
   "errors": {

--- a/packages/snap/locales/en.json
+++ b/packages/snap/locales/en.json
@@ -8,6 +8,7 @@
   "lxp": "You have {count} LXP",
   "balance": "LXP Balance",
   "balanceLxpL": "LXP-L Balance",
+  "pendingBalanceLxpL": "Pending LXP-L",
   "address": "Address",
   "pohStatus": "POH Status",
   "activations": {
@@ -16,12 +17,12 @@
     "one": "There is {count} active LXP activation"
   },
   "lxpAddress": {
-    "heading": "Linea XP wallet address",
+    "heading": "LXP wallet address",
     "prompt": "Please enter the wallet address linked to your LXP"
   },
   "nextSteps": {
     "heading": "Thank you for installing the Linea Voyager Snap",
-    "body": "Next, set your address with the [companion site](https://voyager-snap.linea.build/) to track your Linea XP balance. At any time you can open the Snaps menu and click on LXP to view your balance, Proof of Humanity status, and current activations."
+    "body": "Next, set your address with the [companion site](https://voyager-snap.linea.build/) to track your LXP balance. At any time you can open the Snaps menu and click on LXP to view your balance, Proof of Humanity status, and current activations."
   },
   "noAddress": {
     "toSetText": "To view your LXP balance and POH status,",

--- a/packages/snap/locales/es.json
+++ b/packages/snap/locales/es.json
@@ -7,6 +7,7 @@
   },
   "lxp": "Tienes {count} LXP",
   "balance": "Balance LXP",
+  "balanceLxpL": "Balance LXP-L",
   "address": "Cuenta",
   "pohStatus": "Estado de POH",
   "activations": {
@@ -28,6 +29,7 @@
   },
   "help": "Tu balance de LXP solo incluye entregas completadas. No incluye entregas pendientes de finalizar.",
   "viewBalance": "Ve tu balance de LXP en Lineascan",
+  "viewLxpLBalance": "Ve tu balance de LXP-L en Lineascan",
   "completePOH": "Verfica tu estado de POH",
   "exploreAll": "Explora todas las activaciones",
   "errors": {

--- a/packages/snap/locales/es.json
+++ b/packages/snap/locales/es.json
@@ -16,6 +16,7 @@
     "none": "No hay activas activaciones de LXP",
     "one": "Hay {count} activacion de LXP activa"
   },
+  "lineaEns": "Dominio Linea ENS",
   "lxpAddress": {
     "heading": "Cuenta que usas para LXP",
     "prompt": "Ingresa tu cuenta para ver tu balance"
@@ -31,8 +32,10 @@
   "help": "Tu balance de LXP solo incluye entregas completadas. No incluye entregas pendientes de finalizar.",
   "viewBalance": "Ve tu balance de LXP en Lineascan",
   "viewLxpLBalance": "Ve tu balance de LXP-L en Lineascan",
-  "completePOH": "Verfica tu estado de POH",
+  "completePOH": "Verifica tu estado de POH",
   "exploreAll": "Explora todas las activaciones",
+  "manageLineaEns": "Gestiona tu dominio Linea ENS",
+  "getLineaEns": "Consigue tu dominio Linea ENS",
   "errors": {
     "heading": "Error",
     "invalidLxpAddress": "{address} no es una cuenta valido. Por favor, inténtelo de nuevo más tarde."

--- a/packages/snap/locales/es.json
+++ b/packages/snap/locales/es.json
@@ -8,6 +8,7 @@
   "lxp": "Tienes {count} LXP",
   "balance": "Balance LXP",
   "balanceLxpL": "Balance LXP-L",
+  "pendingBalanceLxpL": "Pendiente LXP-L",
   "address": "Cuenta",
   "pohStatus": "Estado de POH",
   "activations": {
@@ -16,7 +17,7 @@
     "one": "Hay {count} activacion de LXP activa"
   },
   "lxpAddress": {
-    "heading": "Cuenta que usas para Linea XP",
+    "heading": "Cuenta que usas para LXP",
     "prompt": "Ingresa tu cuenta para ver tu balance"
   },
   "nextSteps": {

--- a/packages/snap/locales/fr.json
+++ b/packages/snap/locales/fr.json
@@ -6,7 +6,8 @@
     "notVerified": "Non vérifié"
   },
   "lxp": "Vous avez {count} LXP",
-  "balance": "Quantité LXP",
+  "balance": "Balance LXP",
+  "balanceLxpL": "Balance LXP-L",
   "address": "Adresse",
   "pohStatus": "Statut POH",
   "activations": {
@@ -27,7 +28,8 @@
     "toSetLink": "commencez par définir votre adresse"
   },
   "help": "Votre balance de LXP ne montre que les drops onchain terminés. Elle n'inclut pas les activations en attente de drops.",
-  "viewBalance": "Voir votre balance sur Lineascan",
+  "viewBalance": "Voir votre balance de LXP sur Lineascan",
+  "viewLxpLBalance": "Voir votre balance de LXP-L sur Lineascan",
   "completePOH": "Réalisez votre POH",
   "exploreAll": "Explorez les Activations Linea",
   "errors": {

--- a/packages/snap/locales/fr.json
+++ b/packages/snap/locales/fr.json
@@ -8,6 +8,7 @@
   "lxp": "Vous avez {count} LXP",
   "balance": "Balance LXP",
   "balanceLxpL": "Balance LXP-L",
+  "pendingBalanceLxpL": "LXP-L en attente",
   "address": "Adresse",
   "pohStatus": "Statut POH",
   "activations": {
@@ -16,12 +17,12 @@
     "one": "Il y a {count} activation LXP active"
   },
   "lxpAddress": {
-    "heading": "Adresse du portefeuille Linea XP",
+    "heading": "Adresse du portefeuille LXP",
     "prompt": "Veuillez saisir l'adresse de votre wallet lié à vos LXP"
   },
   "nextSteps": {
     "heading": "Merci d'avoir installé le Snap Linea Voyager",
-    "body": "Ensuite, définissez votre adresse avec le [site web](https://voyager-snap.linea.build/) pour suivre votre solde Linea XP. À tout moment, vous pouvez ouvrir le menu Snaps et cliquer sur LXP pour voir votre solde, votre statut de POH, et les activations actuelles."
+    "body": "Ensuite, définissez votre adresse avec le [site web](https://voyager-snap.linea.build/) pour suivre votre solde LXP. À tout moment, vous pouvez ouvrir le menu Snaps et cliquer sur LXP pour voir votre solde, votre statut de POH, et les activations actuelles."
   },
   "noAddress": {
     "toSetText": "Pour votre votre balance de LXP et votre statut de POH,",

--- a/packages/snap/locales/fr.json
+++ b/packages/snap/locales/fr.json
@@ -16,6 +16,7 @@
     "none": "Il n'y a pas d'activation active",
     "one": "Il y a {count} activation LXP active"
   },
+  "lineaEns": "Domaine Linea ENS",
   "lxpAddress": {
     "heading": "Adresse du portefeuille LXP",
     "prompt": "Veuillez saisir l'adresse de votre wallet lié à vos LXP"
@@ -33,6 +34,8 @@
   "viewLxpLBalance": "Voir votre balance de LXP-L sur Lineascan",
   "completePOH": "Réalisez votre POH",
   "exploreAll": "Explorez les Activations Linea",
+  "manageLineaEns": "Gérez votre domaine Linea ENS",
+  "getLineaEns": "Obtenez votre domaine Linea ENS",
   "errors": {
     "heading": "Erreur",
     "invalidLxpAddress": "{address} n'est pas une adresse valide. Veuillez réessayer."

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@consensys/linea-voyager",
   "version": "0.8.0",
-  "description": "View your minted Linea XP and XP-L balances, POH status, and current activations.",
+  "description": "View your minted LXP and LXP-L balances, POH status, and current activations.",
   "repository": {
     "type": "git",
     "url": "https://github.com/Consensys/linea-voyager-snap"

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@consensys/linea-voyager",
-  "version": "0.7.1",
-  "description": "View your minted Linea XP balance, POH status, and current activations.",
+  "version": "0.8.0",
+  "description": "View your minted Linea XP and XP-L balances, POH status, and current activations.",
   "repository": {
     "type": "git",
     "url": "https://github.com/Consensys/linea-voyager-snap"

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@consensys/linea-voyager",
   "version": "0.8.0",
-  "description": "View your minted LXP and LXP-L balances, POH status, and current activations.",
+  "description": "View your minted LXP and LXP-L balances, POH status, Linea ENS domain and current LXP activations.",
   "repository": {
     "type": "git",
     "url": "https://github.com/Consensys/linea-voyager-snap"
@@ -28,6 +28,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@metamask/abi-utils": "^2.0.2",
     "@metamask/snaps-sdk": "3.2.0",
     "@metamask/utils": "^8.4.0",
     "buffer": "^6.0.3"

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,13 +1,13 @@
 {
-  "version": "0.7.1",
-  "description": "View your minted Linea XP balance, POH status, and current activations.",
+  "version": "0.8.0",
+  "description": "View your minted Linea XP and XP-L balances, POH status, and current activations.",
   "proposedName": "Linea Voyager",
   "repository": {
     "type": "git",
     "url": "https://github.com/Consensys/linea-voyager-snap"
   },
   "source": {
-    "shasum": "4KvbsHMOXo78Qvx0obc09pb80mgJgYoBMexokSLOkGw=",
+    "shasum": "2My9G4XwszoiZBB42qFoehZnvb+FW/NB87aXFznl/yA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,13 +1,13 @@
 {
   "version": "0.8.0",
-  "description": "View your minted LXP and LXP-L balances, POH status, and current activations.",
+  "description": "View your minted LXP and LXP-L balances, POH status, Linea ENS domain and current LXP activations.",
   "proposedName": "Linea Voyager",
   "repository": {
     "type": "git",
     "url": "https://github.com/Consensys/linea-voyager-snap"
   },
   "source": {
-    "shasum": "qn+fCn/bffFvogA9Ac9AQYZ4ffji8hrk9O85XTagYJg=",
+    "shasum": "zGUJj1CB3fST1W0kbTy13/kUXFCSAZMiMjUTEhMebhg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -25,7 +25,8 @@
     "endowment:network-access": {},
     "endowment:rpc": {
       "allowedOrigins": [
-        "https://voyager-snap.linea.build"
+        "https://voyager-snap.linea.build",
+        "http://localhost:8000"
       ]
     },
     "endowment:ethereum-provider": {},

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,13 +1,13 @@
 {
   "version": "0.8.0",
-  "description": "View your minted Linea XP and XP-L balances, POH status, and current activations.",
+  "description": "View your minted LXP and LXP-L balances, POH status, and current activations.",
   "proposedName": "Linea Voyager",
   "repository": {
     "type": "git",
     "url": "https://github.com/Consensys/linea-voyager-snap"
   },
   "source": {
-    "shasum": "2My9G4XwszoiZBB42qFoehZnvb+FW/NB87aXFznl/yA=",
+    "shasum": "qn+fCn/bffFvogA9Ac9AQYZ4ffji8hrk9O85XTagYJg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/api.ts
+++ b/packages/snap/src/api.ts
@@ -1,34 +1,22 @@
-const getData = async (url: string) => {
-  const response = await fetch(url, {
-    method: 'GET',
-  });
+import type { UserData } from './types';
+
+export const callGlobalApi = async (
+  address: string,
+  isLineascan: boolean,
+): Promise<UserData> => {
+  const response = await fetch(
+    `https://lxp-snap-api.netlify.app/.netlify/functions/global-api?address=${address}&isLineascan=${isLineascan}`,
+    {
+      method: 'GET',
+    },
+  );
 
   if (!response.ok) {
-    console.error(`Call to ${url} failed with status ${response.status}`);
+    console.error(
+      `Call to the global API failed with status ${response.status}`,
+    );
     throw new Error(`HTTP error! Status: ${response.status}`);
   }
 
   return response.json();
-};
-
-export const fetchBalanceFromLineascan = async (
-  tokenBalance: string,
-  address: string,
-) => {
-  const res = await getData(
-    `https://api.lineascan.build/api?module=account&action=tokenbalance&contractaddress=${tokenBalance}&address=${address}&tag=latest`,
-  );
-
-  return res.result as string;
-};
-
-export const fetchPohStatus = async (address: string) => {
-  return await getData(`https://linea-xp-poh-api.linea.build/poh/${address}`);
-};
-
-export const fetchLxpActivations = async () => {
-  const result = await getData(
-    'https://lxp-snap-api.netlify.app/.netlify/functions/api',
-  );
-  return result.lxpActivations;
 };

--- a/packages/snap/src/api.ts
+++ b/packages/snap/src/api.ts
@@ -11,9 +11,12 @@ const getData = async (url: string) => {
   return response.json();
 };
 
-export const fetchBalanceFromLineascan = async (address: string) => {
+export const fetchBalanceFromLineascan = async (
+  tokenBalance: string,
+  address: string,
+) => {
   const res = await getData(
-    `https://api.lineascan.build/api?module=account&action=tokenbalance&contractaddress=0xd83af4fbD77f3AB65C3B1Dc4B38D7e67AEcf599A&address=${address}&tag=latest`,
+    `https://api.lineascan.build/api?module=account&action=tokenbalance&contractaddress=${tokenBalance}&address=${address}&tag=latest`,
   );
 
   return res.result as string;

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -35,8 +35,14 @@ export const onHomePage: OnHomePageHandler = async () => {
 
   const myAccount = snapState.lxpAddress as string;
 
-  const { lxpBalance, lxpLBalance, openBlockScore, pohStatus, activations } =
-    await getDataForUser(myAccount, chainId);
+  const {
+    lxpBalance,
+    lxpLBalance,
+    openBlockScore,
+    pohStatus,
+    activations,
+    name,
+  } = await getDataForUser(myAccount, chainId);
 
   await setState({
     myLxpBalance: lxpBalance,
@@ -44,6 +50,7 @@ export const onHomePage: OnHomePageHandler = async () => {
     myOpenBlockScore: openBlockScore,
     myPohStatus: pohStatus,
     activations,
+    myLineaEns: name,
   });
 
   return renderMainUi(myAccount);

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -6,12 +6,7 @@ import type {
 } from '@metamask/snaps-sdk';
 import { isValidHexAddress } from '@metamask/utils';
 
-import {
-  getCurrentActivations,
-  getLxpBalanceForAddress,
-  getLxpLBalanceForAddress,
-  getPohStatus,
-} from './service';
+import { getDataForUser } from './service';
 import {
   renderMainUi,
   renderPromptLxpAddress,
@@ -40,19 +35,14 @@ export const onHomePage: OnHomePageHandler = async () => {
 
   const myAccount = snapState.lxpAddress as string;
 
-  /* make calls in parallel */
-  const [myLxpBalance, myLxpLBalance, myPohStatus, activations] =
-    await Promise.all([
-      getLxpBalanceForAddress(myAccount, chainId),
-      getLxpLBalanceForAddress(myAccount, chainId),
-      getPohStatus(myAccount),
-      getCurrentActivations(),
-    ]);
+  const { lxpBalance, lxpLBalance, openBlockScore, pohStatus, activations } =
+    await getDataForUser(myAccount, chainId);
 
   await setState({
-    myLxpBalance,
-    myLxpLBalance,
-    myPohStatus,
+    myLxpBalance: lxpBalance,
+    myLxpLBalance: lxpLBalance,
+    myOpenBlockScore: openBlockScore,
+    myPohStatus: pohStatus,
     activations,
   });
 

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -9,6 +9,7 @@ import { isValidHexAddress } from '@metamask/utils';
 import {
   getCurrentActivations,
   getLxpBalanceForAddress,
+  getLxpLBalanceForAddress,
   getPohStatus,
 } from './service';
 import {
@@ -40,14 +41,17 @@ export const onHomePage: OnHomePageHandler = async () => {
   const myAccount = snapState.lxpAddress as string;
 
   /* make calls in parallel */
-  const [myLxpBalance, myPohStatus, activations] = await Promise.all([
-    getLxpBalanceForAddress(myAccount, chainId),
-    getPohStatus(myAccount),
-    getCurrentActivations(),
-  ]);
+  const [myLxpBalance, myLxpLBalance, myPohStatus, activations] =
+    await Promise.all([
+      getLxpBalanceForAddress(myAccount, chainId),
+      getLxpLBalanceForAddress(myAccount, chainId),
+      getPohStatus(myAccount),
+      getCurrentActivations(),
+    ]);
 
   await setState({
     myLxpBalance,
+    myLxpLBalance,
     myPohStatus,
     activations,
   });

--- a/packages/snap/src/service.ts
+++ b/packages/snap/src/service.ts
@@ -3,18 +3,26 @@ import {
   fetchLxpActivations,
   fetchPohStatus,
 } from './api';
-import { convertBalanceToDisplay } from './utils';
+import {
+  convertBalanceToDisplay,
+  LXP_CONTRACT_ADDRESS,
+  LXP_L_CONTRACT_ADDRESS,
+} from './utils';
 
 /**
  * Get the LXP balance for an address from Lineascan.
+ * @param tokenAddress - The address of the token contract.
  * @param address - The address to get the LXP balance for.
  * @returns The LXP balance for the address.
  */
-async function getLxpBalanceFromLineascan(address: string) {
+async function getTokenBalanceFromLineascan(
+  tokenAddress: string,
+  address: string,
+) {
   let rawBalance;
 
   try {
-    rawBalance = await fetchBalanceFromLineascan(address);
+    rawBalance = await fetchBalanceFromLineascan(tokenAddress, address);
     return convertBalanceToDisplay(rawBalance);
   } catch (error) {
     return 0;
@@ -22,15 +30,16 @@ async function getLxpBalanceFromLineascan(address: string) {
 }
 
 /**
- * Get the LXP balance for an address from the chain.
+ * Get token balance for an address from the chain.
+ * @param tokenAddress - The address of the token contract.
  * @param address - The address to get the LXP balance for.
  * @returns The LXP balance for the address.
  */
-async function getLxpBalanceFromChain(address: string) {
+async function getTokenBalanceFromChain(tokenAddress: string, address: string) {
   const method = 'eth_call';
   const params = [
     {
-      to: '0xd83af4fbD77f3AB65C3B1Dc4B38D7e67AEcf599A',
+      to: tokenAddress,
       data: `0x70a08231000000000000000000000000${address.slice(2)}`,
     },
     'latest',
@@ -55,9 +64,28 @@ export async function getLxpBalanceForAddress(
     return 0;
   }
   if (chainId === '0xe708') {
-    return getLxpBalanceFromChain(address);
+    return getTokenBalanceFromChain(LXP_CONTRACT_ADDRESS, address);
   }
-  return getLxpBalanceFromLineascan(address);
+  return getTokenBalanceFromLineascan(LXP_CONTRACT_ADDRESS, address);
+}
+
+/**
+ * Get the LXP-L balance for an address.
+ * @param address - The address to get the LXP-L balance for.
+ * @param chainId - The chain ID.
+ * @returns The LXP balance for the address.
+ */
+export async function getLxpLBalanceForAddress(
+  address: string,
+  chainId: string,
+) {
+  if (!address) {
+    return 0;
+  }
+  if (chainId === '0xe708') {
+    return getTokenBalanceFromChain(LXP_L_CONTRACT_ADDRESS, address);
+  }
+  return getTokenBalanceFromLineascan(LXP_L_CONTRACT_ADDRESS, address);
 }
 
 /**

--- a/packages/snap/src/types/index.ts
+++ b/packages/snap/src/types/index.ts
@@ -9,6 +9,7 @@ export type Captions = {
   };
   lxp: string;
   balance: string;
+  balanceLxpL: string;
   address: string;
   pohStatus: string;
   activations: {
@@ -30,6 +31,7 @@ export type Captions = {
   };
   help: string;
   viewBalance: string;
+  viewLxpLBalance: string;
   completePOH: string;
   exploreAll: string;
   errors: {
@@ -65,6 +67,7 @@ export type SnapState = {
   captions?: Captions;
   lxpAddress?: string;
   myLxpBalance?: number;
+  myLxpLBalance?: number;
   myPohStatus?: boolean;
   activations?: Activation[];
 };

--- a/packages/snap/src/types/index.ts
+++ b/packages/snap/src/types/index.ts
@@ -1,5 +1,3 @@
-import type { Address } from '@metamask/snaps-sdk';
-
 export type Captions = {
   locale: string;
   poh: {
@@ -10,6 +8,7 @@ export type Captions = {
   lxp: string;
   balance: string;
   balanceLxpL: string;
+  pendingBalanceLxpL: string;
   address: string;
   pohStatus: string;
   activations: {
@@ -63,17 +62,20 @@ export type Activation = {
   };
 };
 
+export type UserData = {
+  activations: Activation[];
+  pohStatus: boolean;
+  openBlockScore: number;
+  lxpBalance: number;
+  lxpLBalance: number;
+};
+
 export type SnapState = {
   captions?: Captions;
   lxpAddress?: string;
   myLxpBalance?: number;
   myLxpLBalance?: number;
+  myOpenBlockScore?: number;
   myPohStatus?: boolean;
   activations?: Activation[];
-};
-
-export type Payload = {
-  address: Address;
-  signedOn: number;
-  subject: string;
 };

--- a/packages/snap/src/types/index.ts
+++ b/packages/snap/src/types/index.ts
@@ -16,6 +16,7 @@ export type Captions = {
     none: string;
     one: string;
   };
+  lineaEns: string;
   lxpAddress: {
     heading: string;
     prompt: string;
@@ -33,6 +34,8 @@ export type Captions = {
   viewLxpLBalance: string;
   completePOH: string;
   exploreAll: string;
+  manageLineaEns: string;
+  getLineaEns: string;
   errors: {
     heading: string;
     invalidLxpAddress: string;
@@ -68,6 +71,7 @@ export type UserData = {
   openBlockScore: number;
   lxpBalance: number;
   lxpLBalance: number;
+  name: string;
 };
 
 export type SnapState = {
@@ -78,4 +82,5 @@ export type SnapState = {
   myOpenBlockScore?: number;
   myPohStatus?: boolean;
   activations?: Activation[];
+  myLineaEns?: string;
 };

--- a/packages/snap/src/ui.ts
+++ b/packages/snap/src/ui.ts
@@ -28,6 +28,8 @@ export async function renderMainUi(myAccount: string) {
   const lxpLBalance = snapState?.myLxpLBalance ?? 0;
   const openBlockScore = snapState?.myOpenBlockScore ?? 0;
   const activations = snapState?.activations ?? [];
+  const name = snapState?.myLineaEns ?? '';
+
   const captions = snapState?.captions;
 
   const labelBalance = captions?.balance;
@@ -35,6 +37,7 @@ export async function renderMainUi(myAccount: string) {
   const labelPendingLxpLBalance = captions?.pendingBalanceLxpL;
   const labelAddress = captions?.address;
   const labelPohStatus = captions?.pohStatus;
+  const labelLineaEns = captions?.lineaEns;
 
   const pohStatus = `${
     snapState?.myPohStatus
@@ -70,10 +73,12 @@ export async function renderMainUi(myAccount: string) {
   if (myAccount) {
     myData.push(row(labelAddress, address(myAccount as `0x${string}`)));
     myData.push(row(labelBalance, text(`${lxpBalance}`)));
-    myData.push(row(labelLxpLBalance, text(`${lxpLBalance}`)));
-    myData.push(
-      row(labelPendingLxpLBalance, text(`${openBlockScore - lxpLBalance}`)),
-    );
+    if (lxpLBalance > 0) {
+      myData.push(row(labelLxpLBalance, text(`${lxpLBalance}`)));
+      myData.push(
+        row(labelPendingLxpLBalance, text(`${openBlockScore - lxpLBalance}`)),
+      );
+    }
     myData.push(row(labelPohStatus, text(`${pohStatus}`)));
   } else {
     const addressToSetText = captions?.noAddress?.toSetText as string;
@@ -85,11 +90,17 @@ export async function renderMainUi(myAccount: string) {
     );
   }
 
+  if (name && name !== '') {
+    myData.push(row(labelLineaEns, text(name)));
+  }
+
   const help = captions?.help as string;
   const viewBalance = captions?.viewBalance as string;
   const viewLxpLBalance = captions?.viewLxpLBalance as string;
   const completePOH = captions?.completePOH as string;
   const exploreAll = captions?.exploreAll as string;
+  const manageLineaEns = captions?.manageLineaEns as string;
+  const getLineaEns = captions?.getLineaEns as string;
 
   const extraLinks = [];
   extraLinks.push(
@@ -97,11 +108,23 @@ export async function renderMainUi(myAccount: string) {
       `&bull; [${viewBalance}](https://lineascan.build/token/${LXP_CONTRACT_ADDRESS}?a=${myAccount})`,
     ),
   );
+
+  if (lxpLBalance > 0) {
+    extraLinks.push(
+      text(
+        `&bull; [${viewLxpLBalance}](https://lineascan.build/token/${LXP_L_CONTRACT_ADDRESS}?a=${myAccount})`,
+      ),
+    );
+  }
+
   extraLinks.push(
     text(
-      `&bull; [${viewLxpLBalance}](https://lineascan.build/token/${LXP_L_CONTRACT_ADDRESS}?a=${myAccount})`,
+      `&bull; [${
+        name && name !== '' ? manageLineaEns : getLineaEns
+      }](https://names.linea.build/)`,
     ),
   );
+
   if (!snapState?.myPohStatus) {
     extraLinks.push(text(`&bull; [${completePOH}](https://poh.linea.build)`));
   }

--- a/packages/snap/src/ui.ts
+++ b/packages/snap/src/ui.ts
@@ -10,7 +10,12 @@ import {
 } from '@metamask/snaps-sdk';
 
 import banner from '../img/banner.svg';
-import { getState, truncateString } from './utils';
+import {
+  getState,
+  LXP_CONTRACT_ADDRESS,
+  LXP_L_CONTRACT_ADDRESS,
+  truncateString,
+} from './utils';
 
 /**
  * Render the main UI.
@@ -20,10 +25,12 @@ import { getState, truncateString } from './utils';
 export async function renderMainUi(myAccount: string) {
   const snapState = await getState();
   const lxpBalance = snapState?.myLxpBalance ?? 0;
+  const lxpLBalance = snapState?.myLxpLBalance ?? 0;
   const activations = snapState?.activations ?? [];
   const captions = snapState?.captions;
 
   const labelBalance = captions?.balance;
+  const labelLxpLBalance = captions?.balanceLxpL;
   const labelAddress = captions?.address;
   const labelPohStatus = captions?.pohStatus;
 
@@ -61,6 +68,7 @@ export async function renderMainUi(myAccount: string) {
   if (myAccount) {
     myData.push(row(labelAddress, address(myAccount as `0x${string}`)));
     myData.push(row(labelBalance, text(`${lxpBalance}`)));
+    myData.push(row(labelLxpLBalance, text(`${lxpLBalance}`)));
     myData.push(row(labelPohStatus, text(`${pohStatus}`)));
   } else {
     const addressToSetText = captions?.noAddress?.toSetText as string;
@@ -74,13 +82,19 @@ export async function renderMainUi(myAccount: string) {
 
   const help = captions?.help as string;
   const viewBalance = captions?.viewBalance as string;
+  const viewLxpLBalance = captions?.viewLxpLBalance as string;
   const completePOH = captions?.completePOH as string;
   const exploreAll = captions?.exploreAll as string;
 
   const extraLinks = [];
   extraLinks.push(
     text(
-      `&bull; [${viewBalance}](https://lineascan.build/token/0xd83af4fbd77f3ab65c3b1dc4b38d7e67aecf599a?a=${myAccount})`,
+      `&bull; [${viewBalance}](https://lineascan.build/token/${LXP_CONTRACT_ADDRESS}?a=${myAccount})`,
+    ),
+  );
+  extraLinks.push(
+    text(
+      `&bull; [${viewLxpLBalance}](https://lineascan.build/token/${LXP_L_CONTRACT_ADDRESS}?a=${myAccount})`,
     ),
   );
   if (!snapState?.myPohStatus) {

--- a/packages/snap/src/ui.ts
+++ b/packages/snap/src/ui.ts
@@ -26,11 +26,13 @@ export async function renderMainUi(myAccount: string) {
   const snapState = await getState();
   const lxpBalance = snapState?.myLxpBalance ?? 0;
   const lxpLBalance = snapState?.myLxpLBalance ?? 0;
+  const openBlockScore = snapState?.myOpenBlockScore ?? 0;
   const activations = snapState?.activations ?? [];
   const captions = snapState?.captions;
 
   const labelBalance = captions?.balance;
   const labelLxpLBalance = captions?.balanceLxpL;
+  const labelPendingLxpLBalance = captions?.pendingBalanceLxpL;
   const labelAddress = captions?.address;
   const labelPohStatus = captions?.pohStatus;
 
@@ -69,6 +71,9 @@ export async function renderMainUi(myAccount: string) {
     myData.push(row(labelAddress, address(myAccount as `0x${string}`)));
     myData.push(row(labelBalance, text(`${lxpBalance}`)));
     myData.push(row(labelLxpLBalance, text(`${lxpLBalance}`)));
+    myData.push(
+      row(labelPendingLxpLBalance, text(`${openBlockScore - lxpLBalance}`)),
+    );
     myData.push(row(labelPohStatus, text(`${pohStatus}`)));
   } else {
     const addressToSetText = captions?.noAddress?.toSetText as string;

--- a/packages/snap/src/utils.ts
+++ b/packages/snap/src/utils.ts
@@ -2,6 +2,11 @@ import { ManageStateOperation } from '@metamask/snaps-sdk';
 
 import type { Captions, SnapState } from './types';
 
+export const LXP_CONTRACT_ADDRESS =
+  '0xd83af4fbD77f3AB65C3B1Dc4B38D7e67AEcf599A';
+export const LXP_L_CONTRACT_ADDRESS =
+  '0x96B3a15257c4983A6fE9073D8C91763433124B82';
+
 /**
  * Get the snap state.
  * @returns Snap State.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,6 +1647,7 @@ __metadata:
   resolution: "@consensys/linea-voyager@workspace:packages/snap"
   dependencies:
     "@jest/globals": ^29.5.0
+    "@metamask/abi-utils": ^2.0.2
     "@metamask/auto-changelog": 3.4.4
     "@metamask/eslint-config": 12.2.0
     "@metamask/eslint-config-jest": 12.1.0


### PR DESCRIPTION
# Display LXP-L balance

## If connected to Linea

- Fetch total LXP-L from OpenBlock (via the Netlify function)
- Fetch minted LXP-L form Linea

## If connected to any other network

- Fetch total LXP-L from OpenBlock (via the Netlify function)
- Fetch minted LXP-L form Lineascan (via the Netlify function)

# Display Linea ENS domain

## If connected to Linea

- Convert the address to a node hash by calling the `PublicRegistrar` contract
- Fetch the registered domain name from `ReverseRegistrar` contract

## If connected to any other network

- Fetch the registered domain name from the dedicated subgraph (via the Netlify function)

# Notes

- This PR replaces PR #60 

# Preview

<img width="357" alt="image" src="https://github.com/user-attachments/assets/2704089e-6961-45e6-bde1-85f7b996e272">
